### PR TITLE
Wand smelting

### DIFF
--- a/src/main/java/org/sapphon/minecraft/modding/minecraftpython/command/CommandMPEnsorcelItem.java
+++ b/src/main/java/org/sapphon/minecraft/modding/minecraftpython/command/CommandMPEnsorcelItem.java
@@ -4,8 +4,8 @@ import net.minecraft.entity.player.EntityPlayerMP;
 import net.minecraft.item.ItemStack;
 import net.minecraftforge.fml.common.FMLCommonHandler;
 import org.sapphon.minecraft.modding.mcutil.PlayerHelper;
+import org.sapphon.minecraft.modding.minecraftpython.factory.SpellFactory;
 import org.sapphon.minecraft.modding.minecraftpython.item.WandReaderWriter;
-import org.sapphon.minecraft.modding.minecraftpython.spells.StringSpell;
 
 public class CommandMPEnsorcelItem extends CommandMinecraftPythonServer {
 
@@ -34,7 +34,7 @@ public class CommandMPEnsorcelItem extends CommandMinecraftPythonServer {
         if (playerFound != null) {
             ItemStack toEnsorcel = playerFound.getHeldItemMainhand();
             if (toEnsorcel != ItemStack.EMPTY) {
-                WandReaderWriter.recordOntoItem(new StringSpell(spellText), toEnsorcel);
+                WandReaderWriter.recordOntoItem(SpellFactory.createStringSpell(spellText), toEnsorcel);
             }
         }
     }

--- a/src/main/java/org/sapphon/minecraft/modding/minecraftpython/item/WandReaderWriter.java
+++ b/src/main/java/org/sapphon/minecraft/modding/minecraftpython/item/WandReaderWriter.java
@@ -1,10 +1,12 @@
 package org.sapphon.minecraft.modding.minecraftpython.item;
 
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagInt;
 import net.minecraft.nbt.NBTTagLong;
 import net.minecraft.nbt.NBTTagString;
+import net.minecraftforge.fml.common.registry.GameRegistry;
 import org.sapphon.minecraft.modding.minecraftpython.spells.ISpell;
 import org.sapphon.minecraft.modding.minecraftpython.spells.metadata.SpellMetadataConstants;
 
@@ -15,6 +17,16 @@ public class WandReaderWriter {
         setWandRequiredExperience(toRecordOnto, toRecord);
         setWandAuthor(toRecordOnto, toRecord.getAuthorName());
         setWandPython(toRecordOnto, toRecord.getPythonScriptAsString());
+        setWandRecipe(toRecordOnto, toRecord.getSmeltingIngredient());
+    }
+
+    protected static void setWandRecipe(ItemStack toBeSmelted, String ingredientName) {
+        if(!ingredientName.equals(SpellMetadataConstants.NONE)) {
+            Item ingredientItem = Item.getByNameOrId(ingredientName);
+            if(ingredientItem != null) {
+                GameRegistry.addSmelting(ingredientItem, toBeSmelted, 2f);
+            }
+        }
     }
 
     public static boolean isMagicWand(ItemStack itemStack) {
@@ -22,26 +34,26 @@ public class WandReaderWriter {
         return (tagCompound != null && tagCompound.hasKey(SpellMetadataConstants.KEY_SPELL_PYTHON));
     }
 
-    private static void setWandAuthor(ItemStack toAuthorify, String authorName) {
+    protected static void setWandAuthor(ItemStack toAuthorify, String authorName) {
         toAuthorify.setTagInfo(SpellMetadataConstants.KEY_AUTHOR_NAME, new NBTTagString(authorName));
     }
 
-    private static void setWandRequiredExperience(ItemStack toCostify, ISpell toRecord) {
+    protected static void setWandRequiredExperience(ItemStack toCostify, ISpell toRecord) {
         toCostify.setTagInfo(SpellMetadataConstants.KEY_REQUIRED_EXPERIENCE_LEVEL, new NBTTagInt(toRecord.getRequiredExperienceLevels()));
         toCostify.setTagInfo(SpellMetadataConstants.KEY_REQUIRED_EXPERIENCE_POINTS, new NBTTagInt(toRecord.getRequiredExperiencePoints()));
         toCostify.setTagInfo(SpellMetadataConstants.KEY_CONSUMED_EXPERIENCE_LEVELS, new NBTTagInt(toRecord.getConsumedExperienceLevels()));
         toCostify.setTagInfo(SpellMetadataConstants.KEY_CONSUMED_EXPERIENCE_POINTS, new NBTTagInt(toRecord.getConsumedExperiencePoints()));
     }
 
-    private static void setWandCooldown(ItemStack toCooldownify, long cooldownMillis) {
+    protected static void setWandCooldown(ItemStack toCooldownify, long cooldownMillis) {
         toCooldownify.setTagInfo(SpellMetadataConstants.KEY_COOLDOWN_MILLIS, new NBTTagLong(cooldownMillis));
     }
 
-    private static void setWandPython(ItemStack toPythonify, String python) {
+    protected static void setWandPython(ItemStack toPythonify, String python) {
         toPythonify.setTagInfo(SpellMetadataConstants.KEY_SPELL_PYTHON, new NBTTagString(python));
     }
 
-    private static void setWandName(ItemStack toName, String name) {
+    protected static void setWandName(ItemStack toName, String name) {
         if (name.equals(SpellMetadataConstants.NONE)) {
             toName.setStackDisplayName("A Mysterious Pythonic Wand");
         } else {

--- a/src/main/java/org/sapphon/minecraft/modding/minecraftpython/spells/AbstractSpell.java
+++ b/src/main/java/org/sapphon/minecraft/modding/minecraftpython/spells/AbstractSpell.java
@@ -63,6 +63,11 @@ public abstract class AbstractSpell implements ISpell {
     }
 
     @Override
+    public String getSmeltingIngredient() {
+        return getMetadataValueOrNONEIfNotPresent(SpellMetadataConstants.KEY_SMELTING_INGREDIENT);
+    }
+
+    @Override
     public String getAuthorName() {
         String value = getMetadataValueOrNONEIfNotPresent(SpellMetadataConstants.KEY_AUTHOR_NAME);
         if (value.equals(SpellMetadataConstants.NONE)) {

--- a/src/main/java/org/sapphon/minecraft/modding/minecraftpython/spells/ISpell.java
+++ b/src/main/java/org/sapphon/minecraft/modding/minecraftpython/spells/ISpell.java
@@ -22,4 +22,6 @@ public interface ISpell {
     public String getDisplayName();
 
     public long getCooldownInMilliseconds();
+
+    public String getSmeltingIngredient();
 }

--- a/src/main/java/org/sapphon/minecraft/modding/minecraftpython/spells/metadata/SpellMetadataConstants.java
+++ b/src/main/java/org/sapphon/minecraft/modding/minecraftpython/spells/metadata/SpellMetadataConstants.java
@@ -12,4 +12,5 @@ public class SpellMetadataConstants {
     public static final String KEY_REQUIRED_EXPERIENCE_POINTS = "cast_min_xp";
     public static final String KEY_CONSUMED_EXPERIENCE_LEVELS = "cast_level_cost";
     public static final String KEY_CONSUMED_EXPERIENCE_POINTS = "cast_xp_cost";
+    public static final String KEY_SMELTING_INGREDIENT = "smelting_ingredient";
 }


### PR DESCRIPTION
Wands can now include a smelting ingredient in their metadata using `#smelting_ingredient<=>` [https://trello.com/c/qGoK2p6S]